### PR TITLE
chore: Migrate caching from actions to swatinem/rust-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
-      - name: Cache cargo registry and build artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
 
       - name: Fetch dependencies
         run: cargo fetch --locked

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -23,14 +23,8 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Cache cargo registry and build artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
 
       - name: Build CLI
         run: cargo build -p devcontainer-cli
@@ -60,14 +54,8 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Cache cargo registry and build artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
 
       - name: Build CLI
         run: cargo build -p devcontainer-cli


### PR DESCRIPTION
Replace actions/cache with Swatinem/rust-cache@v2.7.5 in all workflows. The rust-cache action is specifically optimized for Rust projects and provides better cache management with less configuration.

Changes:
- ci.yml: Replace manual cache configuration with rust-cache
- smoke.yml: Replace manual cache configuration with rust-cache (both jobs)