### PR TITLE
Add hardened command-line flag for security

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -75,12 +75,18 @@ struct UpArgs {
     skip_post_create: bool,
     #[arg(long = "skip-post-attach")]
     skip_post_attach: bool,
+    #[arg(long, help = "Enable hardened mode: disable all mounts (except workspace), capabilities, and privileges")]
+    hardened: bool,
 }
 
 impl UpArgs {
     async fn run(&self, ctx: &CommandContext) -> Result<()> {
         let source = ctx.config_source();
-        let resolver = ConfigResolver::new(source).with_overrides(ctx.config_overrides());
+        let mut overrides = ctx.config_overrides();
+        if self.hardened {
+            overrides.hardened = true;
+        }
+        let resolver = ConfigResolver::new(source).with_overrides(overrides);
         let resolved = resolver.resolve()?;
 
         let plan = LifecyclePlan::for_up(

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -203,6 +203,8 @@ pub struct ResolvedConfig {
     pub post_create_command: Option<CommandDefinition>,
     #[serde(default)]
     pub post_attach_command: Option<CommandDefinition>,
+    #[serde(default)]
+    pub hardened: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -357,6 +359,7 @@ impl ConfigResolver {
             forward_ports,
             post_create_command,
             post_attach_command,
+            hardened: self.overrides.hardened,
         })
     }
 }
@@ -406,6 +409,7 @@ pub struct ConfigOverrides {
     pub workspace_folder: Option<PathBuf>,
     pub image_reference: Option<String>,
     pub env: Map<String, Value>,
+    pub hardened: bool,
 }
 
 impl ConfigOverrides {

--- a/crates/core/src/lifecycle/mod.rs
+++ b/crates/core/src/lifecycle/mod.rs
@@ -581,6 +581,7 @@ mod tests {
                 "echo".to_string(),
                 "post-attach".to_string(),
             ])),
+            hardened: false,
         }
     }
 
@@ -731,6 +732,7 @@ mod tests {
                     mount_path: PathBuf::from("/data"),
                 }],
                 workspace_mount_path: PathBuf::from("/workspace"),
+                hardened: false,
             })
         }
 

--- a/crates/core/src/provider/mod.rs
+++ b/crates/core/src/provider/mod.rs
@@ -54,6 +54,7 @@ pub struct ProviderPreparation {
     pub networks: Vec<String>,
     pub volumes: Vec<VolumeSpec>,
     pub workspace_mount_path: PathBuf,
+    pub hardened: bool,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/providers/docker/src/lib.rs
+++ b/crates/providers/docker/src/lib.rs
@@ -98,6 +98,7 @@ impl Provider for DockerProvider {
             networks: Vec::new(),
             volumes: Vec::new(),
             workspace_mount_path,
+            hardened: config.hardened,
         })
     }
 
@@ -282,13 +283,34 @@ impl Provider for DockerProvider {
         args.push("--workdir".to_string());
         args.push(workspace_dst.clone());
 
+        // Workspace mount configuration
         args.push("--mount".to_string());
-        args.push(format!("type=bind,src={workspace_src},dst={workspace_dst}"));
+        if preparation.hardened {
+            // In hardened mode, mount workspace as read-only
+            args.push(format!("type=bind,src={workspace_src},dst={workspace_dst},readonly"));
+        } else {
+            args.push(format!("type=bind,src={workspace_src},dst={workspace_dst}"));
+        }
 
-        for volume in &preparation.volumes {
-            let mount_path = path_to_string(&volume.mount_path)?;
-            args.push("--mount".to_string());
-            args.push(format!("type=volume,src={},dst={mount_path}", volume.name));
+        // In hardened mode, skip additional volume mounts
+        if !preparation.hardened {
+            for volume in &preparation.volumes {
+                let mount_path = path_to_string(&volume.mount_path)?;
+                args.push("--mount".to_string());
+                args.push(format!("type=volume,src={},dst={mount_path}", volume.name));
+            }
+        }
+
+        // Hardening: drop all capabilities
+        if preparation.hardened {
+            args.push("--cap-drop".to_string());
+            args.push("ALL".to_string());
+        }
+
+        // Hardening: add security options to prevent privilege escalation
+        if preparation.hardened {
+            args.push("--security-opt".to_string());
+            args.push("no-new-privileges:true".to_string());
         }
 
         args.push(image_reference.to_string());
@@ -656,6 +678,7 @@ mod tests {
             forward_ports: vec![],
             post_create_command: None,
             post_attach_command: None,
+            hardened: false,
         };
 
         let preparation = provider.prepare(&config).await.unwrap();
@@ -690,6 +713,7 @@ mod tests {
             forward_ports: vec![],
             post_create_command: None,
             post_attach_command: None,
+            hardened: false,
         };
 
         let preparation = provider.prepare(&config).await.unwrap();


### PR DESCRIPTION
This commit introduces a --hardened flag to the devcontainer CLI that applies multiple security hardening measures to containers:

- Mounts the workspace as read-only
- Skips all additional volume mounts (only workspace is mounted)
- Drops all Linux capabilities with --cap-drop=ALL
- Adds --security-opt=no-new-privileges:true to prevent privilege escalation

The hardened mode is disabled by default and must be explicitly enabled via the --hardened flag on the 'up' command.

Changes:
- Added --hardened CLI flag to UpArgs
- Added hardened field to ConfigOverrides, ResolvedConfig, and ProviderPreparation
- Updated Docker provider's create_container to apply hardening measures
- Updated all tests to include the new hardened field